### PR TITLE
Fix getNumSurfaces const need

### DIFF
--- a/include/cpphots/interfaces/time_surface.h
+++ b/include/cpphots/interfaces/time_surface.h
@@ -297,7 +297,7 @@ public:
      * 
      * @return number of surfaces
      */
-    virtual size_t getNumSurfaces() = 0;
+    virtual size_t getNumSurfaces() const = 0;
 
 };
 

--- a/include/cpphots/layer.h
+++ b/include/cpphots/layer.h
@@ -323,7 +323,7 @@ public:
         return tspool->sampleContexts(t);
     }
 
-    size_t getNumSurfaces() override {
+    size_t getNumSurfaces() const override {
         return tspool->getNumSurfaces();
     }
 

--- a/include/cpphots/time_surface.h
+++ b/include/cpphots/time_surface.h
@@ -394,7 +394,7 @@ public:
         return ret;
     }
 
-    size_t getNumSurfaces() override {
+    size_t getNumSurfaces() const override {
         return surfaces.size();
     }
 


### PR DESCRIPTION
Add const to getNumSurfaces method. Otherwise, when trying to use this method, a compilation error occurs if you call it inside a const method.